### PR TITLE
fix: 处理插件数据为空时跳过生成插件商店页面

### DIFF
--- a/generate_pluginstore.py
+++ b/generate_pluginstore.py
@@ -65,4 +65,7 @@ highlights:
 
 if __name__ == "__main__":
     plugins = fetch_plugins()
-    generate_md(plugins)
+    if not plugins:
+        print("未获取到插件数据，跳过生成插件商店页面。")
+    else:
+        generate_md(plugins)


### PR DESCRIPTION
当未获取到插件数据时，添加检查以避免生成空页面并输出提示信息