### PR TITLE
ci(workflows): 添加 urllib3 依赖以支持检测链接合理性

### DIFF
--- a/.github/workflows/depeloy.yml
+++ b/.github/workflows/depeloy.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           corepack enable
           npm ci --legacy-peer-deps
-          pip install supabase
+          pip install supabase urllib3
 
       - name: 生成插件商店页面
         env:


### PR DESCRIPTION
检测链接合理性需要 urllib3 作为依赖才能正常工作，因此在部署流程中添加该依赖